### PR TITLE
docs: add TUN mode configuration guide and docker-compose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,40 @@ docker-compose up -d
 这样，你就可以在其他规则中管理收藏夹的规则，所有操作都会同步到 **转发收藏夹** 规则中。
 
 
+---
+
+#### 5. 开启 TUN 模式后的网络配置
+
+开启 tun 模式后，容器内可以使用代理，但外部无法访问容器内服务，解决方法如下：
+
+**简单方法：**
+
+以 host 网络模式重新创建容器，例：`docker run --network host nginx`。
+在本项目中，只需在 `docker-compose.yml` 中取消 `network_mode: host` 的注释即可。
+
+**复杂方法：**
+
+若容器网络是 docker0，忽略这一步，否则先排除接口。
+
+1. 获取代理地址：
+   ```bash
+   # 将 allow-lan 修改为 true（注意设置用户验证）
+   clashmixin -e 
+
+   # 将输出的代理地址中的ip修改为宿主机内网ip，例：http://username:password@192.168.13.115:7890
+   echo $http_proxy
+   ```
+
+2. 为容器配置代理地址：
+   ```bash
+   # 持久化：重新创建容器时，指定代理环境变量，例： 
+   docker run  -e http_proxy="http://username:password@192.168.13.115:7890" nginx
+
+   # 临时：进入容器时，指定代理环境变量，例： 
+   docker exec -e http_proxy=xxx nginx bash
+   ```
+
+
 ## 🛠️ 功能详解
 
 ### ⚡ 过滤流程

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,12 @@ services:
     # ports:
     #   - 9804:8000
     restart: unless-stopped
+    # 如果服务器采用了tun代理模式，请取消以下注释，保持上方port注释
+    network_mode: host # tun模式关键配置
+    env_file:
+      - .env
     volumes:
       - ./db:/app/db
-      - ./.env:/app/.env
       - ./logs:/app/logs
       - ./sessions:/app/sessions
       - ./temp:/app/temp
@@ -24,4 +27,3 @@ services:
         compress: "true"
     stdin_open: true
     tty: true
-


### PR DESCRIPTION
- Update README.md with instructions for TUN mode network configuration
- Add network_mode: host option to docker-compose.yml comments

## 说明
本次更新添加了关于开启 TUN 模式后的网络配置说明。
开启 TUN 模式后，容器内可以使用代理，但外部无法访问容器内服务。

## 解决方法
提供了两种解决方法：

1. **简单方法**：
   在 [docker-compose.yml]中提供了 `network_mode: host` 配置选项（已注释），开启后可直接解决连接问题。

2. **复杂方法**：
   在 [README.md]中添加了详细步骤，包括获取代理地址和为容器配置环境变量的方法。

## 变更内容
- 修改 [docker-compose.yml]：添加 `network_mode: host` 注释选项
- 修改 [README.md]：新增 "开启 TUN 模式后的网络配置" 章节

参考来源：[linux vps tun 模式下 docker冲突解决方案](https://github.com/nelvko/clash-for-linux-install/issues/100#issuecomment-2995667368)